### PR TITLE
Require matplotlib v3.5+.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - scanpy = scanpy.cli:console_main
@@ -26,7 +26,7 @@ requirements:
     - python >=3.8
     - anndata >=0.7.4
     - numpy >=1.17
-    - matplotlib-base >=3.4
+    - matplotlib-base >=3.6
     - pandas >=1.1.1, !=2.1.2
     - scipy >=1.4
     - seaborn !=0.13.0


### PR DESCRIPTION
scanpy requires `matplotlib.colormaps`, which is not in 3.4.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

Attempt number two, this time from a personal repo. (Previously, #11.)